### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # badge-test
 For testing automated PR's
+
+[![](https://images.microbadger.com/badges/image/microscaling/badge-test.svg)](https://microbadger.com/images/microscaling/badge-test "Get your own image badge on microbadger.com")


### PR DESCRIPTION
We saw your image on Docker Hub at [microscaling/badge-test](https://hub.docker.com/r/microscaling/badge-test/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/microscaling/badge-test).
As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/microscaling/badge-test.svg)](https://microbadger.com/images/microscaling/badge-test "Get your own image badge on microbadger.com")

If you have any questions, problems or feedback please let us know through our [issues list](https://github.com/microscaling/microbadger/issues).
