### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # badge-test
 For testing automated PR's
 
-[![Docker Stars](https://img.shields.io/docker/stars/microscaling/badge-test.svg?maxAge=2592000)]() [![Docker Pulls](https://img.shields.io/docker/pulls/microscaling/badge-test.svg?maxAge=2592000)]()
+[![Docker Stars](https://img.shields.io/docker/stars/microscaling/badge-test.svg?maxAge=2592000)]() [![Docker Pulls](https://img.shields.io/docker/pulls/microscaling/badge-test.svg?maxAge=2592000)]() [![](https://images.microbadger.com/badges/image/microscaling/badge-test.svg)](https://microbadger.com/images/microscaling/badge-test "Get your own image badge on microbadger.com")


### PR DESCRIPTION
We saw your image on Docker Hub at [microscaling/badge-test](https://hub.docker.com/r/microscaling/badge-test/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/microscaling/badge-test).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/microscaling/badge-test.svg)](https://microbadger.com/images/microscaling/badge-test "Get your own image badge on microbadger.com")
